### PR TITLE
ci: fix code coverage

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -11,26 +11,15 @@ jobs:
   codecov:
     name: Code coverage
     runs-on: ubuntu-latest
+    container:
+      image: xd009642/tarpaulin:develop-nightly
+      options: --security-opt seccomp=unconfined
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-
-      - uses: Swatinem/rust-cache@v1
-
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          args: "-- --engine llvm --release"
+      - run: |
+          cargo +nightly tarpaulin --verbose --engine llvm --release --out Xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.1

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -25,11 +25,11 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
 
-      - uses: actions-rs/install@v0.1
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
         with:
-          crate: cargo-tarpaulin
-          version: 0.24.0
-      - run: cargo tarpaulin --engine llvm --release
+          version: "0.24.0"
+          args: "-- --engine llvm --release"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.1

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -25,11 +25,12 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
 
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
+      - uses: actions-rs/install@v0.1
         with:
-          version: "0.24.0"
-          args: "-- --engine llvm --release"
+          crate: cargo-tarpaulin
+          version: 0.24.0
+
+      - run: cargo tarpaulin --engine llvm --release
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.1

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -27,12 +27,10 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
 
-      - uses: actions-rs/install@v0.1
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
         with:
-          crate: cargo-tarpaulin
-          version: 0.24.0
-
-      - run: cargo tarpaulin --engine llvm --release
+          args: "-- --engine llvm --release"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.1

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "/home/runner/work/*/::"


### PR DESCRIPTION
# Description

This PR fixes code coverage by following Tarpaulin's [guidelines](https://github.com/xd009642/tarpaulin#github-actions) for using the tool with Github Actions and Codecov.

## Additions and Changes

- The `coverage` workflow is now run within a docker container whose image is provided by Tarpaulin's team
- The tarpaulin command is now run with the `--out Xml` flag

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
